### PR TITLE
Fix output capture

### DIFF
--- a/nopip/__init__.py
+++ b/nopip/__init__.py
@@ -12,7 +12,7 @@ class Install:
         try:
             # Se verbose for True, capture output; se não, não capture
             process = subprocess.run([python_exe, "-m", "pip"] + command,
-                                     check=True, capture_output=not verbose,
+                                     check=True, capture_output=True,
                                      text=True)
             output = process.stdout
         except subprocess.CalledProcessError as cpe:


### PR DESCRIPTION
In non-verbose mode the stdout is still redirected to console (at least on linux)
Do we want the default to be the verbose mode ?